### PR TITLE
Fixed share menu opening issue

### DIFF
--- a/app/js/script.js
+++ b/app/js/script.js
@@ -1,5 +1,9 @@
+
+let shareOpen = false;
+
 document.getElementById('toggle-overlay').addEventListener('click',function(){
-	document.getElementById('overlay').style.display = "flex";
+	shareOpen = shareOpen ? false : true;
+	document.getElementById('overlay').style.display = shareOpen ? 'none' : 'flex';
 });
 
 

--- a/dist/script.js
+++ b/dist/script.js
@@ -1,2 +1,15 @@
-document.getElementById("toggle-overlay").addEventListener("click",(function(){document.getElementById("overlay").style.display="flex"})),console.log("HELLO");const test=()=>{console.log("this is a test")};
+
+let shareOpen = false;
+
+document.getElementById('toggle-overlay').addEventListener('click',function(){
+    document.getElementById('overlay').style.display = shareOpen ? 'none' : 'flex';
+    	shareOpen = shareOpen ? false : true;
+});
+
+
+
+const test = () => {
+	console.log('this is a test');
+};
+//# sourceMappingURL=script.js.map
 //# sourceMappingURL=script.js.map


### PR DESCRIPTION
ISSUE: the share menu was opening as it was supposed to, but in case the user doesn't want to use the share options they can't    close it unless they reload the browser.

FIX : i added a flag that will keep the state of share menu ( whether it's open or not) if it's open then when user clicks on the share button it will close the share menu and vice versa.

Hope it helps
